### PR TITLE
Change authentication to JWT and update oauth2 imports 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Wraps the core big query google API exposing a simple client interface
 
 # Usage
 
-    // basic use
-    bqClient := client.New(PEM_PATH, SERVICE_ACCOUNT_EMAIL, SERVICE_ACCOUNT_CLIENT_ID, SECRET)
+    // basic use 
+    // To get the JSON credantials file : Google Developrs Console -> API Console -> Credentials -> Add Credentials -> Add Service Account -> Download JSON key 
+    bqClient := client.New(JSON_PEM_PATH)
 
     // run a sync query
     query := "select * from publicdata:samples.shakespeare limit 100;"

--- a/client/client.go
+++ b/client/client.go
@@ -22,16 +22,13 @@ const defaultPageSize = 5000
 
 // Client a big query client instance
 type Client struct {
-	accountEmailAddress string
-	userAccountClientID string
-	clientSecret        string
-	pemPath             string
-	token               *oauth2.Token
-	service             *bigquery.Service
-	allowLargeResults   bool
-	tempTableName       string
-	flattenResults      bool
-	PrintDebug          bool
+	pemPath           string
+	token             *oauth2.Token
+	service           *bigquery.Service
+	allowLargeResults bool
+	tempTableName     string
+	flattenResults    bool
+	PrintDebug        bool
 }
 
 // Data is a containing type used for Async data response handling including Headers, Rows and an Error that will be populated in the event of an Error querying
@@ -42,8 +39,11 @@ type Data struct {
 }
 
 // New instantiates a new client with the given params and return a reference to it
-func New(pemPath, serviceAccountEmailAddress, serviceUserAccountClientID, clientSecret string, options ...func(*Client) error) *Client {
-	c := Client{pemPath: pemPath, clientSecret: clientSecret, accountEmailAddress: serviceAccountEmailAddress, userAccountClientID: serviceUserAccountClientID}
+func New(pemPath string, options ...func(*Client) error) *Client {
+	c := Client{
+		pemPath: pemPath,
+	}
+
 	c.PrintDebug = false
 
 	for _, option := range options {


### PR DESCRIPTION
Seems that using the old oauth2 package was causing 401 errors (Auth Error). We moved to a new auth procedure, which is much easier (less things to send to New()).
Running for the last 24 hours we haven't got even one 401 error. 

This also eliminates the https://github.com/golang/go/issues/10193 issue. 